### PR TITLE
Feat/cloudkit

### DIFF
--- a/Pausinha.xcodeproj/xcshareddata/xcschemes/Pausinha.xcscheme
+++ b/Pausinha.xcodeproj/xcshareddata/xcschemes/Pausinha.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "875E1C0F2E74857F0007118A"
+               BuildableName = "Pausinha.app"
+               BlueprintName = "Pausinha"
+               ReferencedContainer = "container:Pausinha.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "875E1C0F2E74857F0007118A"
+            BuildableName = "Pausinha.app"
+            BlueprintName = "Pausinha"
+            ReferencedContainer = "container:Pausinha.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "875E1C0F2E74857F0007118A"
+            BuildableName = "Pausinha.app"
+            BlueprintName = "Pausinha"
+            ReferencedContainer = "container:Pausinha.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Pausinha/ContentView.swift
+++ b/Pausinha/ContentView.swift
@@ -61,5 +61,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
+        .modelContainer(for: [Item.self, UserProfile.self, PublicProfile.self], inMemory: true)
 }

--- a/Pausinha/DataModels/ProfileCategory.swift
+++ b/Pausinha/DataModels/ProfileCategory.swift
@@ -1,0 +1,14 @@
+//
+//  ProfileCategory.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import Foundation
+
+enum ProfileCategory: String, CaseIterable {
+    case bondiano = "Bondiano"
+    case boatardiano = "Boatardiano"
+    case mentoria = "Mentoria"
+}

--- a/Pausinha/DataModels/PublicProfile.swift
+++ b/Pausinha/DataModels/PublicProfile.swift
@@ -1,0 +1,92 @@
+//
+//  PublicProfile.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import Foundation
+import SwiftData
+import CloudKit
+
+@Model
+final class PublicProfile {
+    var id: String?
+    var userID: String?
+    var displayName: String?
+    var profileType: String?
+    var profileImageData: Data?
+    var isActive: Bool?
+    var lastSeen: Date?
+    var createdAt: Date?
+    var recordID: String? // CloudKit record ID
+    
+    init(userID: String, displayName: String, profileType: String, profileImageData: Data? = nil) {
+        self.id = "public_\(userID)" // Unique identifier combining prefix and userID
+        self.userID = userID
+        self.displayName = displayName
+        self.profileType = profileType
+        self.profileImageData = profileImageData
+        self.isActive = true
+        self.lastSeen = Date()
+        self.createdAt = Date()
+    }
+    
+    // CloudKit record
+    func getRecord() -> CKRecord {
+        let recordIDString = self.recordID ?? UUID().uuidString
+        let ckRecordID = CKRecord.ID(recordName: recordIDString)
+        let record = CKRecord(recordType: "PublicProfile", recordID: ckRecordID)
+        record.setValue(self.userID, forKey: "userID")
+        record.setValue(self.displayName, forKey: "displayName")
+        record.setValue(self.profileType, forKey: "profileType")
+        record.setValue(self.profileImageData, forKey: "profileImageData")
+        record.setValue(self.isActive, forKey: "isActive")
+        record.setValue(self.lastSeen, forKey: "lastSeen")
+        record.setValue(self.createdAt, forKey: "createdAt")
+        
+        // Update local recordID if it wasn't set
+        if self.recordID == nil {
+            self.recordID = recordIDString
+        }
+        
+        return record
+    }
+    
+    // Update record ID after CloudKit save
+    func updateRecordID(_ newRecordID: String) {
+        self.recordID = newRecordID
+    }
+    
+    // Init from CloudKit record
+    init(from record: CKRecord) {
+        self.id = "public_\(record["userID"] as? String ?? "")"
+        self.userID = record["userID"] as? String
+        self.displayName = record["displayName"] as? String
+        self.profileType = record["profileType"] as? String
+        self.profileImageData = record["profileImageData"] as? Data
+        self.isActive = record["isActive"] as? Bool
+        self.lastSeen = record["lastSeen"] as? Date
+        self.createdAt = record["createdAt"] as? Date
+        self.recordID = record.recordID.recordName
+    }
+    
+    func updatePublicProfile(name: String? = nil, type: String? = nil, imageData: Data? = nil) {
+        print("PublicProfile: Updating public profile - name: \(name ?? "unchanged"), type: \(type ?? "unchanged"), image: \(imageData != nil ? "updated" : "unchanged")")
+        if let name = name {
+            self.displayName = name
+        }
+        if let type = type {
+            self.profileType = type
+        }
+        if let imageData = imageData {
+            self.profileImageData = imageData
+        }
+        self.lastSeen = Date()
+    }
+    
+    func updateLastSeen() {
+        print("PublicProfile: Updating last seen")
+        self.lastSeen = Date()
+    }
+}

--- a/Pausinha/DataModels/UserProfile.swift
+++ b/Pausinha/DataModels/UserProfile.swift
@@ -1,0 +1,87 @@
+//
+//  UserProfile.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 13/09/25.
+//
+
+import Foundation
+import SwiftData
+import CloudKit
+
+@Model
+final class UserProfile {
+    var userID: String?
+    var userName: String?
+    var profileType: String?
+    var profileImageData: Data?
+    var isPublic: Bool?
+    var createdAt: Date?
+    var updatedAt: Date?
+    var recordID: String? // CloudKit record ID
+    
+    init(userID: String, userName: String, profileType: String = "Bondiano", profileImageData: Data? = nil, isPublic: Bool = true) {
+        self.userID = userID
+        self.userName = userName
+        self.profileType = profileType
+        self.profileImageData = profileImageData
+        self.isPublic = isPublic
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+    
+    // CloudKit record
+    func getRecord() -> CKRecord {
+        let recordIDString = self.recordID ?? UUID().uuidString
+        let ckRecordID = CKRecord.ID(recordName: recordIDString)
+        let record = CKRecord(recordType: "UserProfile", recordID: ckRecordID)
+        record.setValue(self.userID, forKey: "userID")
+        record.setValue(self.userName, forKey: "userName")
+        record.setValue(self.profileType, forKey: "profileType")
+        record.setValue(self.profileImageData, forKey: "profileImageData")
+        record.setValue(self.isPublic, forKey: "isPublic")
+        record.setValue(self.createdAt, forKey: "createdAt")
+        record.setValue(self.updatedAt, forKey: "updatedAt")
+        
+        // Update local recordID if it wasn't set
+        if self.recordID == nil {
+            self.recordID = recordIDString
+        }
+        
+        return record
+    }
+    
+    // Update record ID after CloudKit save
+    func updateRecordID(_ newRecordID: String) {
+        self.recordID = newRecordID
+    }
+    
+    // Init from CloudKit record
+    init(from record: CKRecord) {
+        self.userID = record["userID"] as? String
+        self.userName = record["userName"] as? String
+        self.profileType = record["profileType"] as? String
+        self.profileImageData = record["profileImageData"] as? Data
+        self.isPublic = record["isPublic"] as? Bool
+        self.createdAt = record["createdAt"] as? Date
+        self.updatedAt = record["updatedAt"] as? Date
+        self.recordID = record.recordID.recordName
+    }
+    
+    func updateProfile(name: String? = nil, type: String? = nil, imageData: Data? = nil, isPublic: Bool? = nil) {
+        print("UserProfile: Updating profile - name: \(name ?? "unchanged"), type: \(type ?? "unchanged"), image: \(imageData != nil ? "updated" : "unchanged"), public: \(isPublic.map { String($0) } ?? "unchanged")")
+        if let name = name {
+            self.userName = name
+        }
+        if let type = type {
+            self.profileType = type
+        }
+        if let imageData = imageData {
+            self.profileImageData = imageData
+        }
+        if let isPublic = isPublic {
+            self.isPublic = isPublic
+        }
+        self.updatedAt = Date()
+    }
+}

--- a/Pausinha/Info.plist
+++ b/Pausinha/Info.plist
@@ -6,5 +6,19 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/Pausinha/Item.swift
+++ b/Pausinha/Item.swift
@@ -10,9 +10,11 @@ import SwiftData
 
 @Model
 final class Item {
-    var timestamp: Date
+    var id: UUID?
+    var timestamp: Date?
     
     init(timestamp: Date) {
+        self.id = UUID()
         self.timestamp = timestamp
     }
 }

--- a/Pausinha/Pausinha.entitlements
+++ b/Pausinha/Pausinha.entitlements
@@ -9,7 +9,9 @@
 		<string>Default</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
+	<array>
+		<string>iCloud.$(CFBundleIdentifier)</string>
+	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudKit</string>

--- a/Pausinha/PausinhaApp.swift
+++ b/Pausinha/PausinhaApp.swift
@@ -13,13 +13,62 @@ struct PausinhaApp: App {
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Item.self,
+            UserProfile.self,
+            PublicProfile.self,
         ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
+        
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            print("PausinhaApp: Creating ModelContainer with schema: \(schema)")
+            
+            // Try without CloudKit first to isolate the issue
+            let modelConfiguration = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: false
+            )
+            
+            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            print("PausinhaApp: ✅ ModelContainer created successfully")
+            return container
+        } catch let error as DecodingError {
+            print("PausinhaApp: ❌ DecodingError creating ModelContainer: \(error)")
+            print("PausinhaApp: DecodingError details: \(error.localizedDescription)")
+            // Fallback to in-memory storage
+            let fallbackConfiguration = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: true
+            )
+            do {
+                return try ModelContainer(for: schema, configurations: [fallbackConfiguration])
+            } catch {
+                print("PausinhaApp: ❌ Fallback ModelContainer creation failed: \(error)")
+                fatalError("Fallback ModelContainer creation failed: \(error)")
+            }
         } catch {
-            fatalError("Could not create ModelContainer: \(error)")
+            print("PausinhaApp: ❌ Error creating ModelContainer: \(error)")
+            print("PausinhaApp: Error type: \(type(of: error))")
+            print("PausinhaApp: Error description: \(error.localizedDescription)")
+            
+            // Try to get more detailed error information
+            if let swiftDataError = error as? any LocalizedError {
+                print("PausinhaApp: SwiftData Error reason: \(swiftDataError.errorDescription ?? "Unknown")")
+                print("PausinhaApp: SwiftData Error suggestion: \(swiftDataError.recoverySuggestion ?? "None")")
+            }
+            
+            // Fallback to in-memory storage
+            do {
+                print("PausinhaApp: 🔄 Attempting fallback to in-memory storage")
+                let fallbackConfiguration = ModelConfiguration(
+                    schema: schema,
+                    isStoredInMemoryOnly: true
+                )
+                
+                let container = try ModelContainer(for: schema, configurations: [fallbackConfiguration])
+                print("PausinhaApp: ✅ Fallback ModelContainer created successfully")
+                return container
+            } catch {
+                print("PausinhaApp: ❌ Could not create ModelContainer even with fallback: \(error)")
+                fatalError("Could not create ModelContainer even with fallback: \(error)")
+            }
         }
     }()
 

--- a/Pausinha/Services/AuthService.swift
+++ b/Pausinha/Services/AuthService.swift
@@ -7,17 +7,110 @@
 
 import Foundation
 import AuthenticationServices
+import SwiftData
+import CloudKit
 
 class AuthService: NSObject, ObservableObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     
     @Published var userID: String?
     @Published var userName: String?
+    @Published var currentUserProfile: UserProfile?
+    @Published var currentPublicProfile: PublicProfile?
+    @Published var isUpdating = false
+    @Published var lastError: String?
     private var completion: ((Result<ASAuthorizationAppleIDCredential, Error>) -> Void)?
+    private var modelContext: ModelContext?
+    private let cloudKitService = CloudKitService()
     
     override init() {
         super.init()
         self.userID = UserDefaults.standard.string(forKey: "appleUserID")
         self.userName = UserDefaults.standard.string(forKey: "appleUserName")
+    }
+    
+    // Set model context for database operations
+    func setModelContext(_ context: ModelContext) {
+        self.modelContext = context
+        loadCurrentUserProfile()
+        
+        // Initialize CloudKit
+        Task {
+            await cloudKitService.initializeCloudKit()
+        }
+    }
+    
+    // Load current user profile from database
+    private func loadCurrentUserProfile() {
+        print("AuthService: Loading current user profile")
+        guard let modelContext = modelContext else { return }
+
+        // If we have a userID (from Sign in with Apple or previously saved), load by it
+        if let userID = userID {
+            let privateDescriptor = FetchDescriptor<UserProfile>(
+                predicate: #Predicate { profile in profile.userID == userID }
+            )
+
+            let publicDescriptor = FetchDescriptor<PublicProfile>(
+                predicate: #Predicate { profile in profile.userID == userID }
+            )
+
+            do {
+                let privateProfiles = try modelContext.fetch(privateDescriptor)
+                if let profile = privateProfiles.first {
+                    // Existing private profile found
+                    self.currentUserProfile = profile
+                    self.userName = profile.userName
+                    // Load related public profile
+                    let publicProfiles = try modelContext.fetch(publicDescriptor)
+                    self.currentPublicProfile = publicProfiles.first
+                    return
+                }
+            } catch {
+                print("Erro ao carregar perfil do usuário: \(error)")
+            }
+            // No existing profile found; fall through to create new one
+        }
+
+        // If no userID, try to load any existing UserProfile (first one)
+        let anyDescriptor = FetchDescriptor<UserProfile>()
+        do {
+            let profiles = try modelContext.fetch(anyDescriptor)
+            if let profile = profiles.first {
+                // adopt this existing profile as the current local user
+                self.currentUserProfile = profile
+                self.userID = profile.userID
+                UserDefaults.standard.set(profile.userID, forKey: "appleUserID")
+                self.userName = profile.userName
+                UserDefaults.standard.set(self.userName, forKey: "appleUserName")
+
+                // load related public profile if present
+                let userID = profile.userID
+                let publicDescriptor = FetchDescriptor<PublicProfile>(
+                    predicate: #Predicate { p in p.userID == userID && p.userID != nil }
+                )
+                let publics = try modelContext.fetch(publicDescriptor)
+                self.currentPublicProfile = publics.first
+                return
+            }
+        } catch {
+            print("Erro ao buscar qualquer perfil existente: \(error)")
+        }
+
+        // If no profile exists at all, create a local persistent profile so user data persists
+        let generatedID = UUID().uuidString
+        let startingName = self.userName ?? UserDefaults.standard.string(forKey: "appleUserName") ?? "Usuário"
+        let newProfile = UserProfile(userID: generatedID, userName: startingName)
+        modelContext.insert(newProfile)
+        self.currentUserProfile = newProfile
+        self.userID = generatedID
+        UserDefaults.standard.set(generatedID, forKey: "appleUserID")
+        UserDefaults.standard.set(startingName, forKey: "appleUserName")
+
+        do {
+            try modelContext.save()
+        } catch {
+            print("Erro ao criar perfil inicial: \(error)")
+        }
     }
     
     func signInWithApple(completion: @escaping (Result<ASAuthorizationAppleIDCredential, Error>) -> Void) {
@@ -38,8 +131,15 @@ class AuthService: NSObject, ObservableObject, ASAuthorizationControllerDelegate
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             self.userID = appleIDCredential.user
             UserDefaults.standard.set(appleIDCredential.user, forKey: "appleUserID")
-            self.userName = appleIDCredential.fullName?.givenName ?? appleIDCredential.fullName?.formatted()
+            let fullName = appleIDCredential.fullName?.givenName ?? appleIDCredential.fullName?.formatted()
+            self.userName = fullName
             UserDefaults.standard.set(self.userName, forKey: "appleUserName")
+            
+            // Create or update user profile in database
+            Task {
+                await createOrUpdateUserProfile(userID: appleIDCredential.user, userName: fullName ?? "Usuário")
+            }
+            
             completion?(.success(appleIDCredential))
         } else {
             completion?(.failure(NSError(domain: "AuthService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Credenciais inválidas"])))
@@ -55,6 +155,7 @@ class AuthService: NSObject, ObservableObject, ASAuthorizationControllerDelegate
     // MARK: - ASAuthorizationControllerPresentationContextProviding
     
     func logout() {
+        print("AuthService: Logging out user")
         // Clear persisted login state
         UserDefaults.standard.set(false, forKey: "isLoggedIn")
         // Clean credentials
@@ -62,12 +163,394 @@ class AuthService: NSObject, ObservableObject, ASAuthorizationControllerDelegate
         UserDefaults.standard.removeObject(forKey: "appleUserName")
         self.userID = nil
         self.userName = nil
+        self.currentUserProfile = nil
         // Optionally, perform other cleanup
     }
     
-    // MARK: - ASAuthorizationControllerPresentationContextProviding
+    // MARK: - Profile Management
     
+    private func createOrUpdateUserProfile(userID: String, userName: String) async {
+        guard let modelContext = modelContext else { return }
+        
+        let privateDescriptor = FetchDescriptor<UserProfile>(
+            predicate: #Predicate { profile in profile.userID == userID }
+        )
+        
+        let publicDescriptor = FetchDescriptor<PublicProfile>(
+            predicate: #Predicate { profile in profile.userID == userID }
+        )
+        
+        do {
+            // Handle private profile
+            let privateProfiles = try modelContext.fetch(privateDescriptor)
+            
+            if let existingProfile = privateProfiles.first {
+                // Update existing private profile
+                existingProfile.userName = userName
+                existingProfile.updatedAt = Date()
+                self.currentUserProfile = existingProfile
+                
+                // Save to CloudKit
+                do {
+                    let record = existingProfile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    
+                    // Update recordID if it was newly created
+                    if existingProfile.recordID != savedRecord.recordID.recordName {
+                        existingProfile.recordID = savedRecord.recordID.recordName
+                    }
+                    print("AuthService: Successfully updated existing profile in CloudKit")
+                } catch {
+                    print("AuthService: Failed to update existing profile in CloudKit: \(error.localizedDescription)")
+                }
+            } else {
+                // Create new private profile
+                let newProfile = UserProfile(userID: userID, userName: userName)
+                modelContext.insert(newProfile)
+                self.currentUserProfile = newProfile
+                
+                // Save to CloudKit
+                do {
+                    let record = newProfile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    newProfile.recordID = savedRecord.recordID.recordName
+                    print("AuthService: Successfully created new profile in CloudKit")
+                } catch {
+                    print("AuthService: Failed to create new profile in CloudKit: \(error.localizedDescription)")
+                }
+            }
+            
+            // Handle public profile (if user wants to be visible)
+            let publicProfiles = try modelContext.fetch(publicDescriptor)
+            
+            if let existingPublicProfile = publicProfiles.first {
+                // Update existing public profile
+                existingPublicProfile.displayName = userName
+                existingPublicProfile.updateLastSeen()
+                self.currentPublicProfile = existingPublicProfile
+                
+                // Save to CloudKit
+                do {
+                    let record = existingPublicProfile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    
+                    // Update recordID if it was newly created
+                    if existingPublicProfile.recordID != savedRecord.recordID.recordName {
+                        existingPublicProfile.recordID = savedRecord.recordID.recordName
+                    }
+                    print("AuthService: Successfully updated existing public profile in CloudKit")
+                } catch {
+                    print("AuthService: Failed to update existing public profile in CloudKit: \(error.localizedDescription)")
+                }
+            } else if currentUserProfile?.isPublic == true {
+                // Create new public profile if user wants to be visible
+                let newPublicProfile = PublicProfile(
+                    userID: userID, 
+                    displayName: userName, 
+                    profileType: currentUserProfile?.profileType ?? "Bondiano",
+                    profileImageData: currentUserProfile?.profileImageData
+                )
+                modelContext.insert(newPublicProfile)
+                self.currentPublicProfile = newPublicProfile
+                
+                // Save to CloudKit
+                do {
+                    let record = newPublicProfile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    newPublicProfile.recordID = savedRecord.recordID.recordName
+                    print("AuthService: Successfully created new public profile in CloudKit")
+                } catch {
+                    print("AuthService: Failed to create new public profile in CloudKit: \(error.localizedDescription)")
+                }
+            }
+            
+            try modelContext.save()
+            print("AuthService: Successfully saved profile data locally")
+        } catch {
+            print("Erro ao salvar perfil do usuário: \(error)")
+        }
+    }
+    
+    func updateUserName(_ newName: String) {
+        print("AuthService: Updating user name to \(newName)")
+        guard let modelContext = modelContext, let profile = currentUserProfile else { return }
+        
+        isUpdating = true
+        lastError = nil
+        
+        profile.updateProfile(name: newName)
+        self.userName = newName
+        
+        // Update public profile if it exists and user is public
+        if let publicProfile = currentPublicProfile, profile.isPublic ?? false {
+            publicProfile.updatePublicProfile(name: newName)
+        }
+        
+        // Also update UserDefaults for backwards compatibility
+        UserDefaults.standard.set(newName, forKey: "appleUserName")
+        
+        do {
+            try modelContext.save()
+            // Save to CloudKit asynchronously
+            Task { @MainActor in
+                do {
+                    // Save private profile
+                    let record = profile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    
+                    // Update recordID if it was newly created
+                    if profile.recordID != savedRecord.recordID.recordName {
+                        profile.recordID = savedRecord.recordID.recordName
+                        try modelContext.save()
+                    }
+                    
+                    // Save public profile if exists and user is public
+                    if let publicProfile = currentPublicProfile, profile.isPublic ?? false {
+                        let publicRecord = publicProfile.getRecord()
+                        let savedPublicRecord = try await cloudKitService.saveRecord(publicRecord)
+                        
+                        // Update recordID if it was newly created
+                        if publicProfile.recordID != savedPublicRecord.recordID.recordName {
+                            publicProfile.recordID = savedPublicRecord.recordID.recordName
+                            try modelContext.save()
+                        }
+                    }
+                    
+                    print("AuthService: Successfully synced name update to CloudKit")
+                    isUpdating = false
+                } catch {
+                    print("AuthService: Failed to sync name update to CloudKit: \(error.localizedDescription)")
+                    lastError = "Falha ao sincronizar com o iCloud: \(error.localizedDescription)"
+                    isUpdating = false
+                }
+            }
+        } catch {
+            print("Erro ao atualizar nome do usuário: \(error)")
+            lastError = "Erro ao salvar localmente: \(error.localizedDescription)"
+            isUpdating = false
+        }
+    }
+    
+    func updateProfileType(_ newType: String) {
+        print("AuthService: Updating profile type to \(newType)")
+        guard let modelContext = modelContext, let profile = currentUserProfile else { return }
+        
+        isUpdating = true
+        lastError = nil
+        
+        profile.updateProfile(type: newType)
+        
+        // Update public profile if it exists and user is public
+        if let publicProfile = currentPublicProfile, profile.isPublic ?? false {
+            publicProfile.updatePublicProfile(type: newType)
+        }
+        
+        do {
+            try modelContext.save()
+            // Save to CloudKit asynchronously
+            Task { @MainActor in
+                do {
+                    // Save private profile
+                    let record = profile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    
+                    // Update recordID if it was newly created
+                    if profile.recordID != savedRecord.recordID.recordName {
+                        profile.recordID = savedRecord.recordID.recordName
+                        try modelContext.save()
+                    }
+                    
+                    // Save public profile if exists and user is public
+                    if let publicProfile = currentPublicProfile, profile.isPublic ?? false {
+                        let publicRecord = publicProfile.getRecord()
+                        let savedPublicRecord = try await cloudKitService.saveRecord(publicRecord)
+                        
+                        // Update recordID if it was newly created
+                        if publicProfile.recordID != savedPublicRecord.recordID.recordName {
+                            publicProfile.recordID = savedPublicRecord.recordID.recordName
+                            try modelContext.save()
+                        }
+                    }
+                    
+                    print("AuthService: Successfully synced profile type update to CloudKit")
+                    isUpdating = false
+                } catch {
+                    print("AuthService: Failed to sync profile type update to CloudKit: \(error.localizedDescription)")
+                    lastError = "Falha ao sincronizar tipo de perfil: \(error.localizedDescription)"
+                    isUpdating = false
+                }
+            }
+        } catch {
+            print("Erro ao atualizar tipo de perfil: \(error)")
+            lastError = "Erro ao salvar tipo de perfil: \(error.localizedDescription)"
+            isUpdating = false
+        }
+    }
+    
+    func updateProfileImage(_ imageData: Data) {
+        print("AuthService: Updating profile image")
+        guard let modelContext = modelContext, let profile = currentUserProfile else { return }
+        
+        isUpdating = true
+        lastError = nil
+        
+        profile.updateProfile(imageData: imageData)
+        
+        // Update public profile if it exists and user is public
+        if let publicProfile = currentPublicProfile, profile.isPublic ?? false {
+            publicProfile.updatePublicProfile(imageData: imageData)
+        }
+        
+        do {
+            try modelContext.save()
+            // Save to CloudKit asynchronously
+            Task { @MainActor in
+                do {
+                    // Save private profile
+                    let record = profile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    
+                    // Update recordID if it was newly created
+                    if profile.recordID != savedRecord.recordID.recordName {
+                        profile.recordID = savedRecord.recordID.recordName
+                        try modelContext.save()
+                    }
+                    
+                    // Save public profile if exists and user is public
+                    if let publicProfile = currentPublicProfile, profile.isPublic ?? false {
+                        let publicRecord = publicProfile.getRecord()
+                        let savedPublicRecord = try await cloudKitService.saveRecord(publicRecord)
+                        
+                        // Update recordID if it was newly created
+                        if publicProfile.recordID != savedPublicRecord.recordID.recordName {
+                            publicProfile.recordID = savedPublicRecord.recordID.recordName
+                            try modelContext.save()
+                        }
+                    }
+                    
+                    print("AuthService: Successfully synced profile image update to CloudKit")
+                    isUpdating = false
+                } catch {
+                    print("AuthService: Failed to sync profile image update to CloudKit: \(error.localizedDescription)")
+                    lastError = "Falha ao sincronizar imagem do perfil: \(error.localizedDescription)"
+                    isUpdating = false
+                }
+            }
+        } catch {
+            print("Erro ao atualizar imagem do perfil: \(error)")
+            lastError = "Erro ao salvar imagem do perfil: \(error.localizedDescription)"
+            isUpdating = false
+        }
+    }
+    
+    func updatePublicVisibility(_ isPublic: Bool) {
+        print("AuthService: Updating public visibility to \(isPublic)")
+        guard let modelContext = modelContext, let profile = currentUserProfile else { return }
+        
+        isUpdating = true
+        lastError = nil
+        
+        profile.updateProfile(isPublic: isPublic)
+        
+        if isPublic && currentPublicProfile == nil {
+            // Create public profile if user wants to be visible
+            let newPublicProfile = PublicProfile(
+                userID: profile.userID ?? "",
+                displayName: profile.userName ?? "",
+                profileType: profile.profileType ?? "Bondiano",
+                profileImageData: profile.profileImageData
+            )
+            modelContext.insert(newPublicProfile)
+            self.currentPublicProfile = newPublicProfile
+        } else if !isPublic && currentPublicProfile != nil {
+            // Remove public profile if user wants to be private
+            if let publicProfile = currentPublicProfile {
+                modelContext.delete(publicProfile)
+                self.currentPublicProfile = nil
+            }
+        }
+        
+        do {
+            try modelContext.save()
+            // Handle CloudKit sync asynchronously
+            Task { @MainActor in
+                do {
+                    // Always save private profile
+                    let record = profile.getRecord()
+                    let savedRecord = try await cloudKitService.saveRecord(record)
+                    
+                    // Update recordID if it was newly created
+                    if profile.recordID != savedRecord.recordID.recordName {
+                        profile.recordID = savedRecord.recordID.recordName
+                        try modelContext.save()
+                    }
+                    
+                    if isPublic {
+                        // Save new public profile to CloudKit
+                        if let publicProfile = currentPublicProfile {
+                            let publicRecord = publicProfile.getRecord()
+                            let savedPublicRecord = try await cloudKitService.saveRecord(publicRecord)
+                            
+                            // Update recordID if it was newly created
+                            if publicProfile.recordID != savedPublicRecord.recordID.recordName {
+                                publicProfile.recordID = savedPublicRecord.recordID.recordName
+                                try modelContext.save()
+                            }
+                        }
+                    } else {
+                        // Delete public profile from CloudKit if it exists
+                        if let publicProfile = currentPublicProfile,
+                           let recordIDString = publicProfile.recordID {
+                            let recordID = CKRecord.ID(recordName: recordIDString)
+                            try await cloudKitService.deleteRecord(withID: recordID)
+                        }
+                    }
+                    
+                    print("AuthService: Successfully synced visibility update to CloudKit")
+                    isUpdating = false
+                } catch {
+                    print("AuthService: Failed to sync visibility update to CloudKit: \(error.localizedDescription)")
+                    lastError = "Falha ao sincronizar visibilidade: \(error.localizedDescription)"
+                    isUpdating = false
+                }
+            }
+        } catch {
+            print("Erro ao atualizar visibilidade do perfil: \(error)")
+            lastError = "Erro ao salvar visibilidade: \(error.localizedDescription)"
+            isUpdating = false
+        }
+    }
+    
+    // MARK: - Public Data Management
+    
+    func fetchAllPublicProfiles() -> [PublicProfile] {
+        guard let modelContext = modelContext else { return [] }
+        
+        let descriptor = FetchDescriptor<PublicProfile>(
+            sortBy: [SortDescriptor(\.lastSeen, order: .reverse)]
+        )
+        
+        do {
+            return try modelContext.fetch(descriptor)
+        } catch {
+            print("Erro ao buscar perfis públicos: \(error)")
+            return []
+        }
+    }
+    
+    func fetchProfileCategories() -> [ProfileCategory] {
+        return ProfileCategory.allCases
+    }
+    
+    // MARK: - ASAuthorizationControllerPresentationContextProviding
+
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return UIApplication.shared.windows.first!
+        // Modern approach for iOS 15+
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first {
+            return window
+        }
+        // Fallback for older versions
+        fatalError("Unable to find presentation anchor")
     }
 }

--- a/Pausinha/Services/CloudKitService.swift
+++ b/Pausinha/Services/CloudKitService.swift
@@ -1,0 +1,234 @@
+//
+//  CloudKitService.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import Foundation
+import CloudKit
+
+@Observable
+class CloudKitService {
+    let container: CKContainer
+    let database: CKDatabase
+    
+    enum CloudKitError: LocalizedError {
+        case accountNotAvailable
+        case networkNotAvailable
+        case permissionDenied
+        case recordNotFound
+        case saveFailure(String)
+        case fetchFailure(String)
+        case deleteFailure(String)
+        
+        var errorDescription: String? {
+            switch self {
+            case .accountNotAvailable:
+                return "Conta do iCloud não está disponível"
+            case .networkNotAvailable:
+                return "Conexão de rede não disponível"
+            case .permissionDenied:
+                return "Permissão negada para acessar o CloudKit"
+            case .recordNotFound:
+                return "Registro não encontrado"
+            case .saveFailure(let message):
+                return "Falha ao salvar: \(message)"
+            case .fetchFailure(let message):
+                return "Falha ao buscar: \(message)"
+            case .deleteFailure(let message):
+                return "Falha ao deletar: \(message)"
+            }
+        }
+    }
+    
+    init() {
+        self.container = CKContainer.default()
+        // Use private database for user-specific data
+        self.database = container.privateCloudDatabase
+    }
+    
+    // Initialize CloudKit and check permissions
+    func initializeCloudKit() async {
+        do {
+            let accountStatus = try await container.accountStatus()
+            print("CloudKitService: Account status: \(accountStatus.rawValue)")
+
+            switch accountStatus {
+            case .available:
+                print("CloudKitService: iCloud account is available")
+                // Note: userDiscoverability permission is deprecated in iOS 17+
+                // We'll handle permissions through the actual operations
+            case .noAccount:
+                print("CloudKitService: No iCloud account configured")
+            case .restricted:
+                print("CloudKitService: iCloud account is restricted")
+            case .couldNotDetermine:
+                print("CloudKitService: Could not determine iCloud account status")
+            case .temporarilyUnavailable:
+                print("CloudKitService: iCloud account is temporarily unavailable")
+            @unknown default:
+                print("CloudKitService: Unknown account status: \(accountStatus.rawValue)")
+            }
+        } catch {
+            print("CloudKitService: Error checking account status: \(error)")
+        }
+    }
+
+    // Request CloudKit permissions (deprecated method removed)
+    // Permissions are now handled through actual CloudKit operations
+    
+    // Check account status
+    func checkAccountStatus() async throws -> Bool {
+        let status = try await container.accountStatus()
+        return status == .available
+    }
+    
+    // Check if CloudKit is properly configured
+    func isCloudKitAvailable() async -> Bool {
+        do {
+            let accountStatus = try await container.accountStatus()
+            if accountStatus != .available {
+                print("CloudKitService: iCloud account not available: \(accountStatus)")
+                return false
+            }
+            print("CloudKitService: iCloud account available")
+            return true
+        } catch {
+            print("CloudKitService: Error checking iCloud account status: \(error)")
+            return false
+        }
+    }
+    
+    // Save or update a record using CKModifyRecordsOperation to avoid insert collisions
+    func saveRecord(_ record: CKRecord) async throws -> CKRecord {
+        print("CloudKitService: Saving record of type \(record.recordType) with ID \(record.recordID.recordName) via modify operation")
+        // Ensure iCloud account available
+        guard await isCloudKitAvailable() else {
+            throw CloudKitError.accountNotAvailable
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            let operation = CKModifyRecordsOperation(recordsToSave: [record], recordIDsToDelete: nil)
+            operation.savePolicy = .changedKeys
+            operation.qualityOfService = .userInitiated
+            operation.modifyRecordsResultBlock = { result in
+                switch result {
+                case .success():
+                    print("CloudKitService: Successfully modified record with ID \(record.recordID.recordName)")
+                    continuation.resume(returning: record)
+                case .failure(let error):
+                    let ckError = error as? CKError ?? CKError(.unknownItem)
+                    print("CloudKitService: Error modifying record: \(ckError.localizedDescription)")
+                    continuation
+                        .resume(throwing: self.mapCloudKitError(ckError))
+                }
+            }
+            database.add(operation)
+        }
+    }
+    
+    // Save multiple records in batch
+    func saveRecords(_ records: [CKRecord]) async throws -> [CKRecord] {
+        print("CloudKitService: Batch saving \(records.count) records")
+        
+        let operation = CKModifyRecordsOperation(recordsToSave: records, recordIDsToDelete: nil)
+        operation.savePolicy = .ifServerRecordUnchanged
+        operation.qualityOfService = .userInitiated
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            operation.modifyRecordsResultBlock = { result in
+                switch result {
+                case .success():
+                    let savedRecords = records // Records are modified in place
+                    print("CloudKitService: Successfully batch saved \(savedRecords.count) records")
+                    continuation.resume(returning: savedRecords)
+                case .failure(let error):
+                    print("CloudKitService: Batch save failed: \(error.localizedDescription)")
+                    continuation
+                        .resume(
+                            throwing: self
+                                .mapCloudKitError(
+                                    error as? CKError ?? error as! CKError
+                                )
+                        )
+                }
+            }
+            
+            database.add(operation)
+        }
+    }
+    
+    // Fetch a record by ID
+    func fetchRecord(withID recordID: CKRecord.ID) async throws -> CKRecord {
+        print("CloudKitService: Fetching record with ID \(recordID.recordName)")
+        
+        do {
+            let record = try await database.record(for: recordID)
+            print("CloudKitService: Successfully fetched record")
+            return record
+        } catch let error as CKError {
+            print("CloudKitService: CloudKit error fetching record: \(error.localizedDescription)")
+            throw mapCloudKitError(error)
+        } catch {
+            print("CloudKitService: Unexpected error fetching record: \(error.localizedDescription)")
+            throw CloudKitError.fetchFailure(error.localizedDescription)
+        }
+    }
+    
+    // Delete a record
+    func deleteRecord(withID recordID: CKRecord.ID) async throws {
+        print("CloudKitService: Deleting record with ID \(recordID.recordName)")
+        
+        do {
+            _ = try await database.deleteRecord(withID: recordID)
+            print("CloudKitService: Successfully deleted record")
+        } catch let error as CKError {
+            print("CloudKitService: CloudKit error deleting record: \(error.localizedDescription)")
+            throw mapCloudKitError(error)
+        } catch {
+            print("CloudKitService: Unexpected error deleting record: \(error.localizedDescription)")
+            throw CloudKitError.deleteFailure(error.localizedDescription)
+        }
+    }
+    
+    // Fetch all records of a type
+    func fetchRecords(ofType recordType: String, limit: Int = 100) async throws -> [CKRecord] {
+        print("CloudKitService: Fetching records of type \(recordType)")
+        
+        let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
+        query.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: false)]
+        
+        do {
+            let result = try await database.records(matching: query, resultsLimit: limit)
+            let records = result.matchResults.compactMap { try? $0.1.get() }
+            print("CloudKitService: Successfully fetched \(records.count) records")
+            return records
+        } catch let error as CKError {
+            print("CloudKitService: CloudKit error fetching records: \(error.localizedDescription)")
+            throw mapCloudKitError(error)
+        } catch {
+            print("CloudKitService: Unexpected error fetching records: \(error.localizedDescription)")
+            throw CloudKitError.fetchFailure(error.localizedDescription)
+        }
+    }
+    
+    // Map CloudKit errors to our custom errors
+    private func mapCloudKitError(_ error: CKError?) -> Error {
+        guard let ckError = error else {
+            return CloudKitError.saveFailure("Erro desconhecido")
+        }
+        
+        switch ckError.code {
+        case .notAuthenticated:
+            return CloudKitError.accountNotAvailable
+        case .networkUnavailable, .networkFailure:
+            return CloudKitError.networkNotAvailable
+        case .permissionFailure:
+            return CloudKitError.permissionDenied
+        case .unknownItem:
+            return CloudKitError.recordNotFound
+        default:
+            return CloudKitError.saveFailure(ckError.localizedDescription)
+        }
+    }
+}

--- a/Pausinha/Views/Community/CommunityView.swift
+++ b/Pausinha/Views/Community/CommunityView.swift
@@ -25,56 +25,43 @@ struct CommunityView: View {
     
     var body: some View {
         NavigationView {
-            VStack {
-                // Category filter
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 12) {
-                        CategoryChip(
-                            title: "Todos",
-                            isSelected: selectedCategory == "Todos"
-                        ) {
-                            selectedCategory = "Todos"
-                        }
-                        
+            List {
+                Section(header:
+                    Picker("Categoria", selection: $selectedCategory) {
+                        Text("Todos").tag("Todos")
                         ForEach(categories, id: \.self) { category in
-                            CategoryChip(
-                                title: category.rawValue,
-                                isSelected: selectedCategory == category.rawValue
-                            ) {
-                                selectedCategory = category.rawValue
-                            }
+                            Text(category.rawValue).tag(category.rawValue)
                         }
                     }
-                    .padding(.horizontal, 20)
-                }
-                .padding(.vertical, 8)
-                
-                // Profiles list
-                if filteredProfiles.isEmpty {
-                    VStack(spacing: 16) {
-                        Image(systemName: "person.3")
-                            .font(.system(size: 60))
-                            .foregroundColor(.gray)
-                        
-                        Text("Nenhum usuário encontrado")
-                            .font(.title2)
-                            .fontWeight(.medium)
-                        
-                        Text("Seja o primeiro a tornar seu perfil público!")
-                            .font(.body)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
+                    .pickerStyle(SegmentedPickerStyle())
+                ) {
+                    if filteredProfiles.isEmpty {
+                        VStack(spacing: 16) {
+                            Image(systemName: "person.3")
+                                .font(.system(size: 60))
+                                .foregroundColor(.gray)
+                            
+                            Text("Nenhum usuário encontrado")
+                                .font(.title2)
+                                .multilineTextAlignment(.center)
+                                .fontWeight(.medium)
+                            
+                            Text("Seja o primeiro a tornar seu perfil público!")
+                                .font(.body)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding(24)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                    } else {
+                        ForEach(filteredProfiles, id: \.userID) { profile in
+                            PublicProfileRow(profile: profile)
+                        }
                     }
-                    .padding(40)
-                    
-                    Spacer()
-                } else {
-                    List(filteredProfiles, id: \.userID) { profile in
-                        PublicProfileRow(profile: profile)
-                    }
-                    .listStyle(PlainListStyle())
                 }
             }
+            .listStyle(PlainListStyle())
+            .navigationBarTitleDisplayMode(.automatic)
             .navigationTitle("Comunidade")
             .onAppear {
                 authService.setModelContext(modelContext)
@@ -88,29 +75,6 @@ struct CommunityView: View {
     
     private func loadData() {
         publicProfiles = authService.fetchAllPublicProfiles()
-        // categories are now static enum cases, no need to fetch
-    }
-}
-
-// MARK: - Category Chip Component
-struct CategoryChip: View {
-    let title: String
-    let isSelected: Bool
-    let action: () -> Void
-    
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(.callout)
-                .fontWeight(.medium)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .background(
-                    Capsule()
-                        .fill(isSelected ? Color.accentColor : Color.gray.opacity(0.2))
-                )
-                .foregroundColor(isSelected ? .white : .primary)
-        }
     }
 }
 

--- a/Pausinha/Views/Community/CommunityView.swift
+++ b/Pausinha/Views/Community/CommunityView.swift
@@ -1,0 +1,177 @@
+//
+//  CommunityView.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import SwiftUI
+import SwiftData
+
+struct CommunityView: View {
+    @Environment(\.modelContext) private var modelContext
+    @StateObject private var authService = AuthService()
+    @State private var publicProfiles: [PublicProfile] = []
+    @State private var categories: [ProfileCategory] = ProfileCategory.allCases
+    @State private var selectedCategory: String = "Todos"
+    
+    var filteredProfiles: [PublicProfile] {
+        if selectedCategory == "Todos" {
+            return publicProfiles
+        } else {
+            return publicProfiles.filter { $0.profileType == selectedCategory }
+        }
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                // Category filter
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        CategoryChip(
+                            title: "Todos",
+                            isSelected: selectedCategory == "Todos"
+                        ) {
+                            selectedCategory = "Todos"
+                        }
+                        
+                        ForEach(categories, id: \.self) { category in
+                            CategoryChip(
+                                title: category.rawValue,
+                                isSelected: selectedCategory == category.rawValue
+                            ) {
+                                selectedCategory = category.rawValue
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+                .padding(.vertical, 8)
+                
+                // Profiles list
+                if filteredProfiles.isEmpty {
+                    VStack(spacing: 16) {
+                        Image(systemName: "person.3")
+                            .font(.system(size: 60))
+                            .foregroundColor(.gray)
+                        
+                        Text("Nenhum usuário encontrado")
+                            .font(.title2)
+                            .fontWeight(.medium)
+                        
+                        Text("Seja o primeiro a tornar seu perfil público!")
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(40)
+                    
+                    Spacer()
+                } else {
+                    List(filteredProfiles, id: \.userID) { profile in
+                        PublicProfileRow(profile: profile)
+                    }
+                    .listStyle(PlainListStyle())
+                }
+            }
+            .navigationTitle("Comunidade")
+            .onAppear {
+                authService.setModelContext(modelContext)
+                loadData()
+            }
+            .refreshable {
+                loadData()
+            }
+        }
+    }
+    
+    private func loadData() {
+        publicProfiles = authService.fetchAllPublicProfiles()
+        // categories are now static enum cases, no need to fetch
+    }
+}
+
+// MARK: - Category Chip Component
+struct CategoryChip: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.callout)
+                .fontWeight(.medium)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? Color.accentColor : Color.gray.opacity(0.2))
+                )
+                .foregroundColor(isSelected ? .white : .primary)
+        }
+    }
+}
+
+// MARK: - Public Profile Row Component
+struct PublicProfileRow: View {
+    let profile: PublicProfile
+    
+    private var timeAgo: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: profile.lastSeen ?? Date(), relativeTo: Date())
+    }
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            // Profile image
+            if let imageData = profile.profileImageData,
+               let uiImage = UIImage(data: imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 60, height: 60)
+                    .clipShape(Circle())
+            } else {
+                Circle()
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: 60, height: 60)
+                    .overlay(
+                        Image(systemName: "person.fill")
+                            .foregroundColor(.gray)
+                            .font(.title2)
+                    )
+            }
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(profile.displayName ?? "Unknown")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                
+                Text(profile.profileType ?? "Bondiano")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                
+                HStack {
+                    Circle()
+                        .fill((profile.isActive ?? false) ? Color.green : Color.gray)
+                        .frame(width: 8, height: 8)
+                    
+                    Text((profile.isActive ?? false) ? "Ativo agora" : "Visto \(timeAgo)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    CommunityView()
+        .modelContainer(for: [PublicProfile.self], inMemory: true)
+}

--- a/Pausinha/Views/Home/Components/CommunityCardView.swift
+++ b/Pausinha/Views/Home/Components/CommunityCardView.swift
@@ -1,0 +1,54 @@
+//
+//  CommunityCardView.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import SwiftUI
+
+public struct CommunityCardView: View {
+    
+    @Binding var isNavigatingCommunity: Bool
+    
+    public var body: some View {
+        // Community section
+        VStack(alignment: .leading, spacing: 12) {
+            VStack (alignment: .leading, spacing: 4) {
+                Text("Academers")
+                    .font(.title2)
+                    .bold()
+                Text("Encontre todos os academers que aderiram a pausinha.")
+                    .font(.body)
+                    .foregroundColor(.gray)
+            }
+            .padding(12)
+            
+            Button(action: {
+                isNavigatingCommunity = true
+            }) {
+                Text("Ver todos")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        Capsule()
+                            .foregroundColor(.accentColor)
+                    )
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 32)
+                .fill(.accent.opacity(0.1))
+                .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
+        )
+
+    }
+}
+
+#Preview {
+    CommunityCardView(isNavigatingCommunity: .constant(false))
+        .padding()
+}

--- a/Pausinha/Views/Home/Components/CommunityCardView.swift
+++ b/Pausinha/Views/Home/Components/CommunityCardView.swift
@@ -8,9 +8,8 @@
 import SwiftUI
 
 public struct CommunityCardView: View {
-    
-    @Binding var isNavigatingCommunity: Bool
-    
+    public var onTap: () -> Void
+
     public var body: some View {
         // Community section
         VStack(alignment: .leading, spacing: 12) {
@@ -24,9 +23,7 @@ public struct CommunityCardView: View {
             }
             .padding(12)
             
-            Button(action: {
-                isNavigatingCommunity = true
-            }) {
+            Button(action: onTap) {
                 Text("Ver todos")
                     .font(.headline)
                     .foregroundColor(.white)
@@ -49,6 +46,6 @@ public struct CommunityCardView: View {
 }
 
 #Preview {
-    CommunityCardView(isNavigatingCommunity: .constant(false))
+    CommunityCardView(onTap: {})
         .padding()
 }

--- a/Pausinha/Views/Home/Components/CreateNewButton.swift
+++ b/Pausinha/Views/Home/Components/CreateNewButton.swift
@@ -1,0 +1,47 @@
+//
+//  CreateNewButton.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import SwiftUI
+
+struct CreateNewButton: View {
+    
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 10) {
+                Image("main_icon")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 180, height: 180)
+                
+                Spacer()
+                    .frame(height: 8)
+                
+                Text("Pausinha?")
+                    .fontWeight(.semibold)
+                    .fontWidth(.expanded)
+                    .font(.title3)
+                    .foregroundColor(.accentColor)
+                
+            }
+            .padding(32)
+            .background(
+                Rectangle()
+                    .fill(Color.white)
+                    .clipShape(.buttonBorder)
+                    .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
+            )
+            .padding(.vertical, 24)
+        }
+    }
+}
+
+#Preview {
+    CreateNewButton(action: {})
+        .padding()
+}

--- a/Pausinha/Views/Home/Components/EmptyPausinhasView.swift
+++ b/Pausinha/Views/Home/Components/EmptyPausinhasView.swift
@@ -1,0 +1,38 @@
+//
+//  EmptyPausinhasView.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import SwiftUI
+
+struct EmptyPausinhasView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "macwindow.and.cursorarrow")
+                .font(.system(size: 48))
+                .foregroundStyle(.accent)
+            
+            VStack(spacing: 4) {
+                Text("Nada por aqui...")
+                    .font(.title2)
+                    .bold()
+                
+                Text("Nenhuma pausinha por aqui hoje")
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+            .strokeBorder(Color.gray.opacity(0.2), lineWidth: 1)
+                .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
+        )
+    }
+}
+
+#Preview {
+    EmptyPausinhasView()
+        .padding()
+}

--- a/Pausinha/Views/Home/HomeView.swift
+++ b/Pausinha/Views/Home/HomeView.swift
@@ -12,10 +12,11 @@ struct HomeView: View {
     // Navigation
     @State private var isNavigating = false
     @State private var isPresentingProfileView = false
+    @State private var isNavigatingCommunity = false
     
     // User authentication state
     @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
-    
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -42,6 +43,9 @@ struct HomeView: View {
                         Spacer()
                     }
                     
+                    // Community card
+                    CommunityCardView(isNavigatingCommunity: $isNavigatingCommunity)
+                
                 }.padding(.horizontal, 24)
             }
             .toolbar {
@@ -78,6 +82,9 @@ struct HomeView: View {
                 }
             }
             )
+            .navigationDestination(isPresented: $isNavigatingCommunity) {
+                CommunityView()
+            }
         }
     }
 }

--- a/Pausinha/Views/Home/HomeView.swift
+++ b/Pausinha/Views/Home/HomeView.swift
@@ -8,32 +8,28 @@
 import SwiftUI
 
 struct HomeView: View {
+    enum Destination: Hashable {
+        case profile
+        case community
+        case settings
+    }
     
-    // Navigation
-    @State private var isNavigating = false
-    @State private var isPresentingProfileView = false
-    @State private var isNavigatingCommunity = false
-    
+    // Navigation path
+    @State private var path: [Destination] = []
+    // CreateNew sheet state
+    @State private var isPresentingCreateNew = false
     // User authentication state
     @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ScrollView {
                 VStack(spacing: 20) {
                     
                     // Header section
-                    VStack(spacing: 10) {
-                        Image("main_icon")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 220, height: 220)
-                        
-                        Text("Iniciar pausinha")
-                            .font(.caption)
-                            .foregroundColor(.gray)
-                        
-                    }.padding(.vertical, 24)
+                    CreateNewButton(action: {
+                        isPresentingCreateNew = true
+                    })
                     
                     // Ongoing title
                     HStack {
@@ -43,8 +39,35 @@ struct HomeView: View {
                         Spacer()
                     }
                     
+                    // Empty state view
+                    EmptyPausinhasView()
+                    
+                    // Upcoming title
+                    HStack {
+                        Text("Próximas")
+                            .font(.title2)
+                            .bold()
+                        Spacer()
+                    }
+                    
+                    // Empty state view
+                    EmptyPausinhasView()
+                    
+                    // Completed title
+                    HStack {
+                        Text("Concluídas")
+                            .font(.title2)
+                            .bold()
+                        Spacer()
+                    }
+                    
+                    // Empty state view
+                    EmptyPausinhasView()
+                    
+                    Spacer().frame(height: 32)
+                    
                     // Community card
-                    CommunityCardView(isNavigatingCommunity: $isNavigatingCommunity)
+                    CommunityCardView(onTap: { path.append(.community) })
                 
                 }.padding(.horizontal, 24)
             }
@@ -52,7 +75,7 @@ struct HomeView: View {
                 // Settings button
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: {
-                        // Action for menu button
+                        path.append(.settings)
                     }) {
                         Image(systemName: "gear")
                             .imageScale(.large)
@@ -62,11 +85,7 @@ struct HomeView: View {
                 
                 // Profile button
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {
-                        // Navigation to ProfileView
-                        isNavigating = true
-                        isPresentingProfileView = true
-                    }) {
+                    Button(action: { path.append(.profile) }) {
                         Image(systemName: "person.crop.circle")
                             .imageScale(.large)
                             .foregroundColor(.black)
@@ -75,16 +94,21 @@ struct HomeView: View {
             }
             .navigationTitle("Pausinha?")
             .navigationBarTitleDisplayMode(.inline)
-            .navigationDestination(isPresented: $isNavigating, destination:
-                                    {
-                if isPresentingProfileView {
+            .navigationDestination(for: Destination.self) { destination in
+                switch destination {
+                case .profile:
                     ProfileView(isLoggedIn: $isLoggedIn)
+                case .community:
+                    CommunityView()
+                case .settings:
+                    SettingsView()
                 }
             }
-            )
-            .navigationDestination(isPresented: $isNavigatingCommunity) {
-                CommunityView()
+            .interactiveDismissDisabled(true)
+            .sheet(isPresented: $isPresentingCreateNew) {
+                CreateNewPausinhaView()
             }
+            
         }
     }
 }

--- a/Pausinha/Views/Pausinha/CreateNew/CreateNewPausinhaView.swift
+++ b/Pausinha/Views/Pausinha/CreateNew/CreateNewPausinhaView.swift
@@ -1,0 +1,46 @@
+//
+//  CreateNewPausinhaView.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import SwiftUI
+
+struct CreateNewPausinhaView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+            }
+            .navigationTitle("Criar pausinha")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarRole(.navigationStack)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    // Cancel button
+                    Button(action: {
+                        dismiss()
+                    }) {
+                        Text("Voltar")
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    // Create button
+                    Button(action: {
+                        // Action to create a new pausinha
+                    }) {
+                        Text("Criar")
+                            .bold()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    CreateNewPausinhaView()
+}

--- a/Pausinha/Views/Profile/ProfileViewLogged.swift
+++ b/Pausinha/Views/Profile/ProfileViewLogged.swift
@@ -12,6 +12,7 @@ struct ProfileViewLogged: View {
     
     @Binding var isLoggedIn: Bool
     @StateObject private var authService = AuthService()
+    @Environment(\.modelContext) private var modelContext
     
     // Image picker states
     @State private var selectedItem: PhotosPickerItem?
@@ -21,6 +22,12 @@ struct ProfileViewLogged: View {
     @State private var selectedType = "Bondiano"
     @State private var isEditingName = false
     @State private var editedName = ""
+    @State private var isPublicProfile = true
+    
+    // Error handling states
+    @State private var showErrorAlert = false
+    @State private var errorMessage = ""
+    @State private var isUpdating = false
     
     private let typeOptions = ["Bondiano", "Boatardiano", "Mentoria"]
     
@@ -41,10 +48,13 @@ struct ProfileViewLogged: View {
                 }
                 .onChange(of: selectedItem) { _, newItem in
                     guard let newItem = newItem else { return }
+                    print("ProfileViewLogged: Image selected, updating profile image")
                     Task {
                         if let data = try? await newItem.loadTransferable(type: Data.self),
                            let uiImage = UIImage(data: data) {
                             selectedImage = Image(uiImage: uiImage)
+                            // Save image to database
+                            authService.updateProfileImage(data)
                         }
                     }
                 }
@@ -66,10 +76,13 @@ struct ProfileViewLogged: View {
                 }
                 .onChange(of: selectedItem) { _, newItem in
                     guard let newItem = newItem else { return }
+                    print("ProfileViewLogged: Image selected, updating profile image")
                     Task {
                         if let data = try? await newItem.loadTransferable(type: Data.self),
                            let uiImage = UIImage(data: data) {
                             selectedImage = Image(uiImage: uiImage)
+                            // Save image to database
+                            authService.updateProfileImage(data)
                         }
                     }
                 }
@@ -88,9 +101,6 @@ struct ProfileViewLogged: View {
             VStack(spacing: 0) {
                 // Type picker section
                 HStack(spacing: 16) {
-                    Image(systemName: "person.3.fill")
-                        .foregroundColor(.blue)
-                        .frame(width: 20, height: 20)
                     
                     Text("Tipo de Perfil")
                         .font(.body)
@@ -104,6 +114,36 @@ struct ProfileViewLogged: View {
                         }
                     }
                     .pickerStyle(MenuPickerStyle())
+                    .disabled(authService.isUpdating)
+                    .onChange(of: selectedType) { _, newType in
+                        print("ProfileViewLogged: Profile type changed to \(newType)")
+                        // Save profile type to database
+                        authService.updateProfileType(newType)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                
+                Divider()
+                
+                // Public visibility toggle
+                HStack(spacing: 16) {
+                    Image(systemName: "eye")
+                        .foregroundColor(.blue)
+                        .frame(width: 20, height: 20)
+                    
+                    Text("Perfil Público")
+                        .foregroundColor(.primary)
+                        .font(.body)
+                    
+                    Spacer()
+                    
+                    Toggle("", isOn: $isPublicProfile)
+                        .disabled(authService.isUpdating)
+                        .onChange(of: isPublicProfile) { _, newValue in
+                            print("ProfileViewLogged: Public visibility changed to \(newValue)")
+                            authService.updatePublicVisibility(newValue)
+                        }
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
@@ -115,6 +155,7 @@ struct ProfileViewLogged: View {
                     iconColor: .orange,
                     title: "Alterar Nome"
                 ) {
+                    print("ProfileViewLogged: Opening name edit dialog")
                     editedName = authService.userName ?? "Vicente Parmigiani"
                     isEditingName = true
                 }
@@ -125,8 +166,21 @@ struct ProfileViewLogged: View {
             
             Spacer()
             
+            // Sync status indicator
+            if authService.isUpdating {
+                HStack {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Text("Sincronizando...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.bottom, 16)
+            }
+            
             // Logout button
             Button(action: {
+                print("ProfileViewLogged: User logging out")
                 // Log out action using AuthService
                 authService.logout()
                 isLoggedIn = false
@@ -141,17 +195,46 @@ struct ProfileViewLogged: View {
                             .foregroundColor(.red)
                     )
             }
+            .disabled(authService.isUpdating)
         }
         .padding(.horizontal, 24)
+        .onAppear {
+            print("ProfileViewLogged: View appeared, loading profile data")
+            // Configure AuthService with model context
+            authService.setModelContext(modelContext)
+            
+            // Load profile data
+            if let profile = authService.currentUserProfile {
+                selectedType = profile.profileType ?? "Bondiano"
+                isPublicProfile = profile.isPublic ?? true
+                if let imageData = profile.profileImageData,
+                   let uiImage = UIImage(data: imageData) {
+                    selectedImage = Image(uiImage: uiImage)
+                }
+            }
+        }
+        .onChange(of: authService.lastError) { _, error in
+            if let error = error {
+                errorMessage = error
+                showErrorAlert = true
+                authService.lastError = nil // Reset error after showing
+            }
+        }
         .alert("Alterar Nome", isPresented: $isEditingName) {
             TextField("Nome", text: $editedName)
             Button("Cancelar", role: .cancel) { }
             Button("Salvar") {
-                // Aqui você pode salvar o nome usando o AuthService
-                // authService.updateUserName(editedName)
+                print("ProfileViewLogged: Saving new name: \(editedName)")
+                // Save the name using AuthService
+                authService.updateUserName(editedName)
             }
         } message: {
             Text("Digite seu novo nome:")
+        }
+        .alert("Erro", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage)
         }
     }
 }

--- a/Pausinha/Views/Settings/SettingsView.swift
+++ b/Pausinha/Views/Settings/SettingsView.swift
@@ -1,0 +1,14 @@
+//
+//  SettingsView.swift
+//  Pausinha
+//
+//  Created by Vicente Parmigiani on 14/09/25.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text("SettingsView")
+    }
+}


### PR DESCRIPTION
This pull request adds support for user and public profiles to the app, including their data models and CloudKit integration. It introduces new SwiftData models, a CloudKit service for syncing profile data, and updates app configuration to enable iCloud and CloudKit. The changes also improve error handling when initializing the model container and expand supported device orientations.

**Profile Data Models and CloudKit Integration**

* Added new SwiftData models: `UserProfile` and `PublicProfile`, each with CloudKit sync methods and initializers for seamless data exchange between local and cloud storage. (`Pausinha/DataModels/UserProfile.swift` [[1]](diffhunk://#diff-1f2f348ad397e1e24ce3c19172ec5b718b7b53da36005291818a4b53fbe8fbdfR1-R87) `Pausinha/DataModels/PublicProfile.swift` [[2]](diffhunk://#diff-a5ce1276f236a83080f7d9a4854bb9eba8c317745e46f4cdf2d853f635c8d6a7R1-R92)
* Implemented `CloudKitService` to handle saving, fetching, updating, and deleting records in CloudKit, with custom error mapping and support for batch operations. (`Pausinha/Services/CloudKitService.swift` [Pausinha/Services/CloudKitService.swiftR1-R234](diffhunk://#diff-aaf26a1b8205d3674d21d23f0ccd8dace02b384a3546d5359aff2e5cc7f51031R1-R234))

**App Configuration and Initialization**

* Updated the app’s model container to include `UserProfile` and `PublicProfile`, with improved error handling and fallback to in-memory storage if initialization fails. (`Pausinha/PausinhaApp.swift` [Pausinha/PausinhaApp.swiftR16-R71](diffhunk://#diff-2c8c8291ae030d4b5f3b18df11b0e3065b4a3cff7909a05da8c523ec523e9a25R16-R71))
* Modified the preview configuration and model container setup to support the new models. (`Pausinha/ContentView.swift` [Pausinha/ContentView.swiftL64-R64](diffhunk://#diff-8d98fa450eaf96a8fe29ba2801cf7cd9dd58f34fccf274b311b8694399770d70L64-R64))

**iCloud and CloudKit Enablement**

* Updated entitlements to include the correct iCloud container identifier and enable CloudKit services. (`Pausinha/Pausinha.entitlements` [Pausinha/Pausinha.entitlementsL12-R14](diffhunk://#diff-8c62bf1c4ff4a72aa772f4b6a8b5b0f9977f10b061cc1e763b283ea508b20acfL12-R14))

**Other Improvements**

* Added a new `ProfileCategory` enum for profile categorization. (`Pausinha/DataModels/ProfileCategory.swift` [Pausinha/DataModels/ProfileCategory.swiftR1-R14](diffhunk://#diff-76c09367687ac264cbc39cbf55b0f88f17494e86f8d02bcddb20212912dd5dfbR1-R14))
* Expanded supported interface orientations for both iPhone and iPad in the app’s plist. (`Pausinha/Info.plist` [Pausinha/Info.plistR9-R22](diffhunk://#diff-624252989d12fc5cf034411e607c0015a1c8615b79d0b20cd537ac1fda655caaR9-R22))
* Updated the `Item` model to include an `id` property and make `timestamp` optional. (`Pausinha/Item.swift` [Pausinha/Item.swiftL13-R17](diffhunk://#diff-9d0dafc5ef180af589c286cde236c2b584108b1d70d9d4077115aef88af06263L13-R17))